### PR TITLE
QB progression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ staticfiles/*.json
 staticfiles/admin/*
 staticfiles/gdanalyst/*
 staticfiles/*.py
+staticfiles/empty.*.txt
 gd/sec.py
 gd/sec1.py

--- a/gd/settings.py
+++ b/gd/settings.py
@@ -11,7 +11,11 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 import django_heroku
 import os
-from gd.sec1 import *
+try:
+    from gd.sec1 import *
+except:
+    print("Missing gd.sec1 file is expected on Heroku Dev and Production environments as this file is not needed.")
+    continue
 import logging
 from pathlib import Path
 import sentry_sdk

--- a/gd/settings.py
+++ b/gd/settings.py
@@ -11,11 +11,14 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 import django_heroku
 import os
+
+# Uncomment this section if running locally
+"""
 try:
     from gd.sec1 import *
 except:
     print("Missing gd.sec1 file is expected on Heroku Dev and Production environments as this file is not needed.")
-    continue
+"""
 import logging
 from pathlib import Path
 import sentry_sdk

--- a/gdanalyst/static/gdanalyst/data_table.js
+++ b/gdanalyst/static/gdanalyst/data_table.js
@@ -27,6 +27,8 @@ var th_dict = {
     "DPM": "DPM = Defensive Play Maker",
     "PBP": "PBP = Play by Play Text",
     "YPEN": "YPEN = Penalty Yards",
+    "Prg": "Prg = QB Progression",
+    "Prgx": "Prgx = Prg Details",
     "H": "H = Home Score",
     "A": "A = Away Score",
 };
@@ -41,7 +43,7 @@ $(document).ready( function () {
         responsive: true,
         stateSave: false,
         colReorder: {
-            order: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 27, 24, 25, 26, 28, 29 ]
+            order: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 28, 29, 17, 18, 19, 20, 21, 22, 23, 27, 24, 25, 26, 30, 31 ]
         },
         dom: 'PBfrtip',
         lengthMenu: [
@@ -75,10 +77,10 @@ $(document).ready( function () {
                 searchPanes:{
                     show: false,
                 },
-                targets: [3, 4, 10, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
+                targets: [3, 4, 10, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31],
             },
             {
-                "visible": false, "targets": 26,
+                "visible": false, "targets": [26, 29]
             },
             {
                 "width": "300px", "targets": 26,
@@ -87,8 +89,8 @@ $(document).ready( function () {
     });
     // $('#gameresult').DataTable().searchPanes.rebuildPane();
     console.log('DOM fully loaded and parsed');
-    var x = document.querySelectorAll('.dataTables_scrollBody')
-    var i = 0
+    var x = document.querySelectorAll('.dataTables_scrollBody');
+    var i = 0;
     for (i = 0; i < x.length; i++) {
         console.log(x[i]);
         x[i].style.height = "125px";

--- a/gdanalyst/templates/gdanalyst/gameresult.html
+++ b/gdanalyst/templates/gdanalyst/gameresult.html
@@ -49,6 +49,8 @@
                 <th>DPM</th>
                 <th>PBP</th>
                 <th>YPEN</th>
+                <th>Prg</th>
+                <th>Prgx</th>
                 <th>H</th>
                 <th>A</th>
             </tr>


### PR DESCRIPTION
Implemented concept of tracking QB progression by parsing play by play text to find instances where QB progresses through receiver options. Two columns are added to the Game Results datatable output.

1. **Prg** = QB Progression (this column is visible by default): This will be a number in the range 1 through 5. If it is a 1, this means the QB looked at 1 receiving option. If it is a 5, this means the QB progressed through 5 receiving options.
2. **Prgx** = Prg Details (this column is hidden by default): This contains additional progression details in a format that follows this syntax --> {Off player},{Def player in coverage},{how well covered},{pass depth of off player such as Short, Medium, Long, etc...}. If info for one of these is not available, it will be replaced with an underscore character "_".

Examples:
1: WR1,CB1,C,M         # WR1 covered (C) by CB1 at Medium pass depth
2: RB2, LB2,WC,S       # RB2 well covered (WC) by LB2 at Short pass depth
3: WR2,FS,_,L             # WR2 with FS in coverage at Long pass depth (and this last one in list is who the QB threw the pass to and it should match the OPM, CVR, CVRG, PD columns)
