### PR TITLE
Show hide searchpanes

### DIFF
--- a/gdanalyst/static/gdanalyst/data_table.js
+++ b/gdanalyst/static/gdanalyst/data_table.js
@@ -49,7 +49,7 @@ $(document).ready( function () {
         searchPanes:{
           cascadePanes: true,
         },
-        dom: 'QPBfrtip',
+        dom: '<"#collapseSearch.searchpanes row collapse show"QP>Bfiprtip',
         lengthMenu: [
             [ 50, 100, -1 ],
             [ '50 rows', '100 rows', 'Show all' ]

--- a/gdanalyst/static/gdanalyst/data_table.js
+++ b/gdanalyst/static/gdanalyst/data_table.js
@@ -49,7 +49,7 @@ $(document).ready( function () {
         searchPanes:{
           cascadePanes: true,
         },
-        dom: '<"#collapseSearch.searchpanes row collapse show"QP>Bfiprtip',
+        dom: '<"#collapseSearch.searchpanes m-1 row collapse show"QP><"m-1"Bfiprtip>',
         lengthMenu: [
             [ 50, 100, -1 ],
             [ '50 rows', '100 rows', 'Show all' ]
@@ -79,7 +79,7 @@ $(document).ready( function () {
                 targets: [3,4,6,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32],
             },
             {
-                "visible": false, "targets": [26, 29, 30, 31]
+                "visible": false, "targets": [13, 18, 26, 27, 29, 30, 31]
             },
             {
                 "width": "300px", "targets": 26,
@@ -560,6 +560,32 @@ $(document).ready( function () {
             }
         }
     });
+
+    // switchboxes to show/hide the charts div and the search filters div
+    const switchCharts = document.querySelector('#flexCheckCharts');
+    const switchSearchFilters = document.querySelector('#flexCheckSearchFilters');
+    const divCharts = document.querySelector('#collapseRow');
+    const divSearchFilters = document.querySelector('#collapseSearch');
+
+    switchCharts.addEventListener('change', () => {
+      if (switchCharts.checked) {
+        // If Charts is checked, show the charts div
+        divCharts.style.display = "flex";
+      } else {
+        // If Charts is unchecked, do not show the charts div
+        divCharts.style.display = "none";
+      }
+    }); 
+
+    switchSearchFilters.addEventListener('change', () => {
+      if (switchSearchFilters.checked) {
+        // If Charts is checked, show the charts div
+        divSearchFilters.style.display = "flex";
+      } else {
+        // If Charts is unchecked, do not show the charts div
+        divSearchFilters.style.display = "none";
+      }
+    }); 
 });
 
 

--- a/gdanalyst/static/gdanalyst/data_table.js
+++ b/gdanalyst/static/gdanalyst/data_table.js
@@ -46,7 +46,10 @@ $(document).ready( function () {
         colReorder: {
             order: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 28, 29, 17, 18, 19, 20, 21, 22, 23, 27, 24, 25, 26, 30, 31, 32]
         },
-        dom: 'PBfrtip',
+        searchPanes:{
+          cascadePanes: true,
+        },
+        dom: 'QPBfrtip',
         lengthMenu: [
             [ 50, 100, -1 ],
             [ '50 rows', '100 rows', 'Show all' ]
@@ -62,23 +65,18 @@ $(document).ready( function () {
             },
             'csv', 'excel',
         ],
-        searchPanes:{
-            columns:[0, 1, 2, 5, 6, 7, 8, 9, 11],
-            cascadePanes: true,
-            layout: 'columns-9',
-        },
         columnDefs:[
             {
                 searchPanes:{
-                    show: true,
+                    show: true
                 },
-                targets: [0, 1, 2, 5, 6, 7, 8, 9, 11],
+                targets: [0,1,2,5,7,8,9,10,11]
             },
             {
                 searchPanes:{
                     show: false,
                 },
-                targets: [3, 4, 10, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32],
+                targets: [3,4,6,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32],
             },
             {
                 "visible": false, "targets": [26, 29, 30, 31]

--- a/gdanalyst/templates/gdanalyst/gameresult.html
+++ b/gdanalyst/templates/gdanalyst/gameresult.html
@@ -21,6 +21,9 @@
         <button class="btn btn-primary m-1" type="button" data-toggle="collapse" data-target="#collapseRow" aria-expanded="false" aria-controls="collapseRow">
             Show/Hide Charts
         </button>
+        <button class="btn btn-primary m-1" type="button" data-toggle="collapse" data-target="#collapseSearch" aria-expanded="true" aria-controls="collapseSearch">
+            Show/Hide Search Filters
+        </button>
     </p>
     <div class="chartcontainer">
         <div class="row collapse show" id="collapseRow" style="height: 200px;">

--- a/gdanalyst/templates/gdanalyst/gameresult.html
+++ b/gdanalyst/templates/gdanalyst/gameresult.html
@@ -7,7 +7,7 @@
 
 {% block styles %}
      
-<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/jszip-2.5.0/dt-1.11.3/b-2.1.1/b-colvis-2.1.1/b-html5-2.1.1/cr-1.5.5/fc-4.0.1/fh-3.2.0/r-2.2.9/sp-1.4.0/sl-1.3.4/datatables.min.css"/>
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/jszip-2.5.0/dt-1.11.3/b-2.1.1/b-colvis-2.1.1/b-html5-2.1.1/cr-1.5.5/fh-3.2.0/r-2.2.9/sb-1.3.4/sp-1.4.0/sl-1.3.4/datatables.min.css"/>
     <link href="{% static 'gdanalyst/gameresult.css' %}" rel="stylesheet">
      
     <!--

--- a/gdanalyst/templates/gdanalyst/gameresult.html
+++ b/gdanalyst/templates/gdanalyst/gameresult.html
@@ -18,12 +18,18 @@
 
 {% block body %}
     <p>
-        <button class="btn btn-primary m-1" type="button" data-toggle="collapse" data-target="#collapseRow" aria-expanded="false" aria-controls="collapseRow">
-            Show/Hide Charts
-        </button>
-        <button class="btn btn-primary m-1" type="button" data-toggle="collapse" data-target="#collapseSearch" aria-expanded="true" aria-controls="collapseSearch">
-            Show/Hide Search Filters
-        </button>
+        <div class="form-check form-switch">
+            <input class="m-1 form-check-input checked" type="checkbox" value="" id="flexCheckCharts" checked>
+            <label class="form-check-label" for="flexCheckCharts">
+              Show Charts
+            </label>
+        </div>
+        <div class="form-check form-switch">
+            <input class="m-1 form-check-input checked" type="checkbox" value="" id="flexCheckSearchFilters" checked>
+            <label class="form-check-label" for="flexCheckSearchFilters">
+              Show Search Filters
+            </label>
+        </div>
     </p>
     <div class="chartcontainer">
         <div class="row collapse show" id="collapseRow" style="height: 200px;">

--- a/gdanalyst/templates/gdanalyst/layout.html
+++ b/gdanalyst/templates/gdanalyst/layout.html
@@ -41,11 +41,11 @@
         {% endblock %}
 
         {% block script %}
-            <script src="https://code.jquery.com/jquery-3.5.1.js"></script>
+            <script src="https://code.jquery.com/jquery-3.6.0.js" integrity="sha256-H+K7U5CnXl1h5ywQfKtSj8PCmoN9aaq30gDh27Xc0jk=" crossorigin="anonymous"></script>
             <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
             <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
-             
-            <script type="text/javascript" src="https://cdn.datatables.net/v/dt/jszip-2.5.0/dt-1.11.3/b-2.1.1/b-colvis-2.1.1/b-html5-2.1.1/cr-1.5.5/fc-4.0.1/fh-3.2.0/r-2.2.9/sp-1.4.0/sl-1.3.4/datatables.min.js"></script>
+
+            <script type="text/javascript" src="https://cdn.datatables.net/v/dt/jszip-2.5.0/dt-1.11.3/b-2.1.1/b-colvis-2.1.1/b-html5-2.1.1/cr-1.5.5/fh-3.2.0/r-2.2.9/sb-1.3.4/sp-1.4.0/sl-1.3.4/datatables.min.js"></script>
             <script type="text/javascript" src="https://code.highcharts.com/highcharts.js"></script>
             <script type="text/javascript" src="https://code.highcharts.com/highcharts-more.js"></script>
             <script type="text/javascript" src="https://code.highcharts.com/modules/data.js"></script>


### PR DESCRIPTION
1. Added switches to toggle on/off the display of Charts and the Search Filters. This is useful if you have a small display and want to quickly show/hide these elements.
2. Added what is called a "Search Builder". It offers more advanced methods of filtering the data in the table. You can filter by any column in the table and combine AND/OR logic to customize the filtering behavior further.
3. Added a column called "Scr" which indicates the scoring margin of the offensive team. A positive number means the offensive team is ahead by that many points. A negative number means the offensive team is behind that many points. This was a gap compared to the Yatzr tool.
4. In order to save space and reduce the width of the table, by default I have hidden the Prx (Pass Results Extra Detail), YPEN (Yards Penalty), H (Home Score), A (Away Score) columns. If you want to see these columns, click the Column Visibility button and enable them.